### PR TITLE
OAS-7090 | Updated base image (old image isn't allowed anymore)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         type: boolean
         default: false
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:2023.02.1
     environment:
       DOCKER_BUILDKIT: 1
       BUILDX_PLATFORMS: linux/amd64,linux/arm64


### PR DESCRIPTION
<img width="414" alt="image" src="https://user-images.githubusercontent.com/47088745/231233996-3a27ffe5-d6df-470b-b4b2-9abefdade4f6.png">
